### PR TITLE
[Feat] Spring Securtiy+JWT+OAuth2 관련 Auth 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.2'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'org'
@@ -27,11 +27,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     // jwt

--- a/src/main/java/org/doubleone/domain/manager/entity/Manager.java
+++ b/src/main/java/org/doubleone/domain/manager/entity/Manager.java
@@ -30,13 +30,20 @@ public class Manager extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "manager_id", updatable = false)
-  private Long workerId;
+  private Long managerId;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(name = "member_id", updatable = false)
   @NotNull
   @JsonIgnore
   private Member member;
+
+  @Column(name = "name", unique = true)
+  @NotNull
+  private String name;
+
+  @Column(name = "profile_img", columnDefinition = "TEXT")
+  private String profileImg;
 
   @Column(name = "phone_num", unique = true)
   @NotNull

--- a/src/main/java/org/doubleone/domain/member/controller/AuthController.java
+++ b/src/main/java/org/doubleone/domain/member/controller/AuthController.java
@@ -3,6 +3,13 @@ package org.doubleone.domain.member.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.member.dto.request.TokenRequestDto;
+import org.doubleone.domain.member.dto.response.TokenResponseDto;
+import org.doubleone.domain.member.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/token")
+  public ResponseEntity<TokenResponseDto> reissuedAccessToken(@RequestBody TokenRequestDto requestDto){
+    return ResponseEntity.status(HttpStatus.OK).body(authService.reissueAccessToken(requestDto.refreshToken()));
+  }
 
 }

--- a/src/main/java/org/doubleone/domain/member/dto/request/TokenRequestDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/request/TokenRequestDto.java
@@ -1,0 +1,7 @@
+package org.doubleone.domain.member.dto.request;
+
+public record TokenRequestDto(
+    String refreshToken
+) {
+
+}

--- a/src/main/java/org/doubleone/domain/member/dto/response/TokenResponseDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/response/TokenResponseDto.java
@@ -1,0 +1,9 @@
+package org.doubleone.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponseDto(
+    String accessToken
+) {
+}

--- a/src/main/java/org/doubleone/domain/member/entity/Member.java
+++ b/src/main/java/org/doubleone/domain/member/entity/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ import org.doubleone.global.BaseTimeEntity;
 @Table(name = "member")
 @Getter
 @Log4j2
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
@@ -28,21 +30,11 @@ public class Member extends BaseTimeEntity {
   @Column(name = "member_id", updatable = false)
   private Long memberId;
 
-  @Column(name = "kakao_id", updatable = false, unique = true)
-  private Long kakaoId;
-
   @Column(name = "email", unique = true)
   private String email;
 
   @Column(name = "password")
   private String password;
-
-  @Column(name = "name", unique = true)
-  @NotNull
-  private String name;
-
-  @Column(name = "profile_img", columnDefinition = "TEXT")
-  private String profileImg;
 
   @Column(name = "member_type")
   @NotNull
@@ -55,15 +47,11 @@ public class Member extends BaseTimeEntity {
   private MemberStatus memberstatus;
 
   @Builder
-  public Member(Long kakaoId, String email, String password, String name, MemberType memberType) {
-    this.kakaoId = kakaoId;
+  public Member(String email, String password) {
     this.email = email;
     this.password = password;
-    this.name = name;
-    this.profileImg = null;
     this.memberstatus = MemberStatus.ACTIVE;
-    this.memberType = memberType;
+    this.memberType = MemberType.UNKNOWN;
   }
-
 
 }

--- a/src/main/java/org/doubleone/domain/member/entity/MemberType.java
+++ b/src/main/java/org/doubleone/domain/member/entity/MemberType.java
@@ -2,5 +2,6 @@ package org.doubleone.domain.member.entity;
 
 public enum MemberType {
   MANAGER,
-  WORKER
+  WORKER,
+  UNKNOWN
 }

--- a/src/main/java/org/doubleone/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/doubleone/domain/member/repository/MemberRepository.java
@@ -1,7 +1,9 @@
 package org.doubleone.domain.member.repository;
 
+import java.util.Optional;
 import org.doubleone.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long>{
 
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/doubleone/domain/member/service/AuthService.java
+++ b/src/main/java/org/doubleone/domain/member/service/AuthService.java
@@ -1,0 +1,54 @@
+package org.doubleone.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.member.dto.response.TokenResponseDto;
+import org.doubleone.domain.member.entity.Member;
+import org.doubleone.domain.member.repository.MemberRepository;
+import org.doubleone.global.exception.CustomException;
+import org.doubleone.global.exception.ErrorCode;
+import org.doubleone.global.jwt.TokenProvider;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+  private final MemberRepository memberRepository;
+  private final TokenProvider tokenProvider;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  /**
+   * AccessToken 재발급
+   *
+   * 클라이언트가 전달한 리프레시 토큰을 검증해 유효한 경우 새로운 액세스토큰을 발급한다.
+   */
+  public TokenResponseDto reissueAccessToken(String refreshToken){
+    // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
+    String email = tokenProvider.extractEmail(refreshToken);
+    Member member = getUserByEmail(email);
+    // Redis에서 해당 사용자 Id를 키로 하는 리프래시 토큰 가져오기
+    String storedRefreshToken = redisTemplate.opsForValue().get(member.getMemberId().toString());
+    // 전달받은 리프레시 토큰과 Redis에 저장된 리프레시 토큰이 일치하는지 확인
+    if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+      throw new CustomException(ErrorCode.INVALID_TOKEN);
+    }
+    // 일치한다면 새로운 AccessToken 생성
+    String accessToken = tokenProvider.createAccessToken(member);
+    return TokenResponseDto.builder()
+        .accessToken(accessToken)
+        .build();
+  }
+
+  /**
+   * Email로 사용자 객체 가져오기
+   */
+  @Transactional(readOnly = true)
+  public Member getUserByEmail(String email){
+    return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 이메일로 사용자를 찾을 수 없습니다."));
+  }
+
+}

--- a/src/main/java/org/doubleone/domain/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/doubleone/domain/member/service/CustomOAuth2UserService.java
@@ -1,0 +1,67 @@
+package org.doubleone.domain.member.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.member.entity.Member;
+import org.doubleone.domain.member.repository.MemberRepository;
+import org.doubleone.global.exception.CustomException;
+import org.doubleone.global.exception.ErrorCode;
+import org.doubleone.global.utils.OAuth2UserInfo;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+  private final MemberRepository memberRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    // OAuth2 사용자 정보 로드
+    OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+    // OAuth2UserInfo 객체 생성하여 kakaoId 추출
+    OAuth2UserInfo oAuth2UserInfo = new OAuth2UserInfo(oAuth2User.getAttributes());
+
+    // email이 null인지 확인
+    if (oAuth2UserInfo.getEmail() == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    // DB에서 email로 사용자 조회, 없으면 새로 생성
+    Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail())
+        .orElseGet(() -> createMember(oAuth2UserInfo));
+
+    // 사용자 속성 생성
+    Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+    attributes.put("id", member.getMemberId());
+    attributes.put("email", member.getEmail());
+
+    // DefaultOAuth2User 객체 생성하여 반환
+    return new DefaultOAuth2User(
+        Collections.singleton(new OAuth2UserAuthority(attributes)),
+        attributes,
+        "email"); // 기본 식별자 지정
+  }
+
+  // 사용자 생성 메서드
+  private Member createMember(OAuth2UserInfo oAuth2UserInfo) {
+    Member member = Member.builder()
+        .email(oAuth2UserInfo.getEmail())
+        .password("")
+        .build();
+    return memberRepository.save(member);
+  }
+}
+

--- a/src/main/java/org/doubleone/domain/member/service/MemberService.java
+++ b/src/main/java/org/doubleone/domain/member/service/MemberService.java
@@ -7,6 +7,8 @@ import org.doubleone.domain.member.repository.MemberRepository;
 import org.doubleone.global.BaseTimeEntity;
 import org.doubleone.global.exception.CustomException;
 import org.doubleone.global.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,13 +20,12 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
 
-  // 개발 진행을 위한 임시 메서드
-  public Member getCurrentMember(){
-    return memberRepository.findById((long)1).get();
-  }
-
-  public Member getOtherMember(){
-    return memberRepository.findById((long)2).get();
+  @Transactional(readOnly = true)
+  public Member getCurrentMember() throws CustomException {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Member member = memberRepository.findByEmail(authentication.getName())
+        .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+    return member;
   }
 
   public Member getMemberById(Long memberId){

--- a/src/main/java/org/doubleone/domain/worker/entity/Worker.java
+++ b/src/main/java/org/doubleone/domain/worker/entity/Worker.java
@@ -40,6 +40,13 @@ public class Worker extends BaseTimeEntity {
   @JsonIgnore
   private Member member;
 
+  @Column(name = "name", unique = true)
+  @NotNull
+  private String name;
+
+  @Column(name = "profile_img", columnDefinition = "TEXT")
+  private String profileImg;
+
   @Column(name = "gender")
   @NotNull
   @Enumerated(EnumType.STRING)
@@ -64,15 +71,5 @@ public class Worker extends BaseTimeEntity {
   @Column(name = "license")
   @NotNull
   private String license;
-
-
-
-
-
-
-
-
-
-
 
 }

--- a/src/main/java/org/doubleone/global/config/RedisConfig.java
+++ b/src/main/java/org/doubleone/global/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package org.doubleone.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching // 캐싱 기능 활성화
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Value("${spring.data.redis.password}")
+  private String password;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    LettuceConnectionFactory factory = new LettuceConnectionFactory(host, port);
+    factory.setPassword(password);
+    return factory;
+  }
+
+
+  // redis template를 사용하여  redis에 직접 데이터를 저장하고 조회
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+    return template;
+  }
+}

--- a/src/main/java/org/doubleone/global/config/SecurityConfig.java
+++ b/src/main/java/org/doubleone/global/config/SecurityConfig.java
@@ -1,10 +1,13 @@
 package org.doubleone.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.doubleone.domain.member.service.CustomOAuth2UserService;
+import org.doubleone.global.handler.OAuth2AuthenticationSuccessHandler;
+import org.doubleone.global.jwt.JwtAuthenticationFilter;
+import org.doubleone.global.jwt.TokenProvider;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -12,13 +15,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -30,7 +31,9 @@ import java.util.Arrays;
 @EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
-
+  private final TokenProvider tokenProvider;
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
@@ -76,32 +79,28 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-    http
-        .csrf(AbstractHttpConfigurer::disable)
-        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        .formLogin(AbstractHttpConfigurer::disable)
-        .logout(logout -> logout
-                .logoutUrl("/logout")
-                .deleteCookies("refreshToken")
-//            .addLogoutHandler(logoutHandler)
-                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))
-        )
+    return http
+        // 기본 인증 방식 비활성화 (UI 대신 토큰을 통한 인증을 사용하기 때문)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .headers(header -> header
-            .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-//        // jwt
-//        .addFilterBefore(new JwtFilter(jwtUtil), LogoutFilter.class)
+        // CSRF 보호 비활성화 (토큰 기반 인증이므로 필요하지 않음)
+        .csrf(AbstractHttpConfigurer::disable)
+        // CORS 설정 비활성화
+        .cors(AbstractHttpConfigurer::disable)
+        // 요청에 따른 인증 인가 설정
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(AUTH_WHITELIST).permitAll()
             .anyRequest().permitAll() // jwt 구현 후 authenticated()로 변경
-//            // oauth2
-//            .oauth2Login(oauth -> oauth
-//                .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
-//                .successHandler(oAuth2SuccessHandler));
-        );
-
-    return http.build();
+        )
+        // JWT를 사용하므로 sateless
+        .sessionManagement(
+            sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        )
+        // JWT 인증 필터를 UsernamePAsswordAuthenticationFilter 앞에 추가하여 JWT를 통한 인증 수행
+        .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+        // OAuth2 로그인 설정 - 인증된 사용자 정보(프로필)를 가져오는 방식 정의, 인증 성공시 동작을 정의하는 successHandler 설정
+        .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+            .successHandler(oAuth2AuthenticationSuccessHandler))
+        .build();
   }
 }
+

--- a/src/main/java/org/doubleone/global/exception/ErrorCode.java
+++ b/src/main/java/org/doubleone/global/exception/ErrorCode.java
@@ -7,6 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+  // Auth
+  UNAUTHORIZED(401, "인증 정보가 누락되거나 잘못되었습니다."),
+  ACCESS_DENIED(403, "접근 권한이 없습니다."),
+  INVALID_SIGNATURE(401, "잘못된 JWT 서명입니다."),
+  EXPIRED_ACCESS_TOKEN(401, "만료된 엑세스 토큰입니다."),
+  INVALID_TOKEN(400, "잘못된 토큰입니다."),
+  UNSUPPORTED_TOKEN(400, "지원하지 않는 토큰입니다."),
+  EMPTY_CLAIMS(400, "JWT 클레임이 비어있습니다."),
+
   // Member
   MEMBER_NOT_FOUND(404, "멤버를 찾을 수 없습니다."),
 

--- a/src/main/java/org/doubleone/global/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/org/doubleone/global/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,56 @@
+package org.doubleone.global.handler;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.member.entity.Member;
+import org.doubleone.domain.member.repository.MemberRepository;
+import org.doubleone.global.exception.CustomException;
+import org.doubleone.global.exception.ErrorCode;
+import org.doubleone.global.jwt.TokenProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final TokenProvider tokenProvider;
+  private final MemberRepository memberRepository;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    // OAuth2 인증된 사용자 정보 가져오기
+    DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+    // 사용자 속성에서 이메일 추출
+    String email = (String) oAuth2User.getAttributes().get("email");
+
+    // email을 통해 데이터베이스에서 Member 조회
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    // AccessToken, RefreshToken 발급
+    String accessToken = tokenProvider.createAccessToken(member);
+    String refreshToken = tokenProvider.createRefreshToken(member);
+
+    // 리프레시토큰 저장
+    tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+    // JSON형식 응답 설정
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+
+    // AccessToken, RefreshToken 토큰 전달
+    String jsonResponse = String.format("{\"accessToken\":\"%s\", \"refreshToken\":\"%s\"}", accessToken, refreshToken);
+    response.getWriter().write(jsonResponse);
+    response.getWriter().flush();
+  }
+}

--- a/src/main/java/org/doubleone/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/doubleone/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package org.doubleone.global.jwt;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+  private final TokenProvider tokenProvider;
+
+  private static final String BEARER = "Bearer ";
+  private static final String HEADER = "Authorization";
+
+  /**
+   * JWT 인증 필터
+   *
+   * HTTP 요청을 가로채 JWT 토큰을 검사하고, 유효한 경우 인증 정보를 설정
+   */
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    // 요청 헤더의 Authorization 키 값 조회
+    String authorizationHeader = request.getHeader(HEADER);
+
+    // Bearer 접두사를 제거하여 토큰 추출
+    String token = getAccessToken(authorizationHeader);
+
+    // 토큰이 유효한 경우, 인증 정보를 설정(SecurityContext에 인증정보 저장)하여 해당 요청동안 인증된 사용자 정보를 받아올 수 있게 함
+    if(!ObjectUtils.isEmpty(token) && tokenProvider.isValidToken(token)){
+      Authentication authentication = tokenProvider.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    // 다음 필터로 요청과 응답 전달
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * Authorization 헤더에서 Bearer 접두사를 제거해 토큰 추출
+   */
+  private String getAccessToken(String authorizationHeader){
+    // Token이 null이 아니고 Bearer로 시작해야지 정상적인 Token
+    if(authorizationHeader != null && authorizationHeader.startsWith(BEARER)){
+      // 정상적인 토큰이라면 앞에 Bearer 제거 후 리턴
+      return authorizationHeader.substring(BEARER.length());
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/doubleone/global/jwt/TokenProvider.java
+++ b/src/main/java/org/doubleone/global/jwt/TokenProvider.java
@@ -1,0 +1,156 @@
+package org.doubleone.global.jwt;
+
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.member.entity.Member;
+import org.doubleone.domain.member.repository.MemberRepository;
+import org.doubleone.global.exception.CustomException;
+import org.doubleone.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+
+  // application.yml에 저장한 jwt값 가져오기
+  @Value("${jwt.secretKey}")
+  private String secretKey;
+
+  // 토큰 만료시간 설정
+  private static Long accessTokenExpiration =
+      1000 * 60 * 60L; // 1시간 = 1000(ms->s) * 60(s->m) * 60(m->h)
+  private static Long refreshTokenExpiration =
+      1000 * 60 * 60 * 25 * 14L; // 2주 = 1000(ms->s) * 60(s->m) * 60(m->h) * 24(h->하루) * 14(2주)
+
+  // 토큰에 포함할 기본 정보와 클레임 키값 설정
+  private static final String AUTH_CLAIM = "auth";
+
+  private final MemberRepository memberRepository;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  /**
+   * AccessToken 생성 메소드 사용자 이메일 정보를 포함해 AccessToken 생성
+   */
+  public String createAccessToken(Member member) {
+    Date now = new Date();
+    // 액세스토큰 발급
+    return Jwts.builder()
+        // 헤더 - 토큰 타입: JWT
+        .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+        // 내용 - 토큰이 발급된 시간: 현재 시간
+        .setIssuedAt(now)
+        // 내용 - 토큰 만료 시간: expiredMs 변수값
+        .setExpiration(new Date(now.getTime() + accessTokenExpiration))
+        // 내용 - 토큰 제목: 사용자 이메일
+        .setSubject(member.getEmail())
+        // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .compact();
+  }
+
+  /**
+   * RefreshToken 생성 메소드
+   */
+  public String createRefreshToken(Member member) {
+    Date now = new Date();
+    return Jwts.builder()
+        // 헤더 - 토큰 타입: JWT
+        .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+        // 내용 - 토큰이 발급된 시간: 현재 시간
+        .setIssuedAt(now)
+        // 내용 - 토큰 만료 시간: expiredMs 변수값
+        .setExpiration(new Date(now.getTime() + refreshTokenExpiration))
+        // 내용 - 토큰 제목: 사용자 이메일
+        .setSubject(member.getEmail())
+        // 서명 - 시크릿키와 함께 해시값을 HS256 방식으로 암호화
+        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .compact();
+  }
+
+  /**
+   * Redis에 리프레시 토큰을 저장하는 메소드 key: 사용자 ID, value: 리프레시 토큰 리프레시토큰 만료 시간(refreshTokenExpiration)을
+   * 만료시간으로 정해 자동으로 삭제되도록 설정
+   */
+  public void saveRefreshToken(Long userId, String refreshToken) {
+    // Redis에 리프레시 토큰 저장
+    redisTemplate.opsForValue()
+        .set(userId.toString(), refreshToken, Duration.ofMillis(refreshTokenExpiration));
+  }
+
+  /**
+   * AccessToken에서 email 추출 토큰이 유효한지 확인 후 이메일 클레임 값을 추출
+   */
+  public String extractEmail(String accessToken) {
+    if (isValidToken(accessToken)) {
+      return getClaims(accessToken).getSubject();
+    }
+    return null;
+  }
+
+  /**
+   * 유효한 토큰인지 검증
+   */
+  public boolean isValidToken(String token) {
+    try {
+      // secretKey를 사용해 토큰 복호화
+      Jwts.parser()
+          .setSigningKey(secretKey)
+          .build()
+          .parseClaimsJws(token);
+      return true;
+    } catch (SecurityException | MalformedJwtException e) {
+      // Token이 잘못된 경우
+      throw new CustomException(ErrorCode.INVALID_TOKEN);
+    } catch (ExpiredJwtException e) {
+      // 토큰이 만료된 경우
+      throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      // 지원하지 않는 토큰 형식인 경우
+      throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+    } catch (SignatureException e) {
+      // 서명 오류인 경우
+      throw new CustomException(ErrorCode.INVALID_SIGNATURE);
+    } catch (IllegalArgumentException e) {
+      // JWT 클레임 문자열이 비어있는 경우
+      throw new CustomException(ErrorCode.EMPTY_CLAIMS);
+    }
+  }
+
+  /**
+   * 토큰에서 사용자 인증 정보를 꺼내 반환 JWT 토큰의 클레임에서 사용자 이메일과 권한 정보를 추출하여 Authentication 객체를 생성
+   */
+  public Authentication getAuthentication(String token) {
+    // 토큰 복호화
+    Claims claims = getClaims(token);
+
+    // 토큰에서 정보를 꺼냄
+    Set<SimpleGrantedAuthority> authorities = Collections
+        .singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+    return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails
+        .User(claims.getSubject(), "", authorities), token, authorities);
+  }
+
+  /**
+   * 토큰을 복호화한 후 페이로드 반환
+   */
+  private Claims getClaims(String token) {
+    return Jwts.parser()
+        .setSigningKey(secretKey)
+        .build()
+        .parseClaimsJws(token)
+        .getPayload();
+  }
+}

--- a/src/main/java/org/doubleone/global/utils/OAuth2UserInfo.java
+++ b/src/main/java/org/doubleone/global/utils/OAuth2UserInfo.java
@@ -1,0 +1,19 @@
+package org.doubleone.global.utils;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OAuth2UserInfo {
+  private final Map<String, Object> attributes;
+
+  // OAuth2UserInfo 객체 생성자
+  public OAuth2UserInfo(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  // 사용자 이메일 반환 메서드
+  public String getEmail() {
+    return (String) ((Map) attributes.get("kakao_account")).get("email");
+  }
+}


### PR DESCRIPTION
## 📝 구현 기능 
- Spring Securtiy+JWT+OAuth2 구현
- 카카오 로그인 구현
- 토큰 재발급 API 구현 
- Member, Worker, Manager 엔티티 필드 변경

## 💬 코멘트
- 로그인 방법: http://localhost:8080/oauth2/authorization/kakao (테스트용 authorization-uri) 통해서 카카오 로그인 수행
- Swagger: http://localhost:8080/swagger-ui/index.html
- Member, Worker, Manager 엔티티 필드 변경: git pull 받고 코드 실행하실 때 MySQL Workbench에서 스키마 한번 DROP해 주세요 
- [yml 파일](https://www.notion.so/yml-1957e1478a5c80bda079db592d5cfb3a) 업데이트: git pull 받고 함께 업데이트해야 Application 실행 가능
- Redis 설치한 후 켜두어야 Application 실행 가능 
- [redis 비밀번호 설정 방법](https://passwd.tistory.com/entry/Redis-%EB%B9%84%EB%B0%80%EB%B2%88%ED%98%B8-%EC%84%A4%EC%A0%95) 참고해서 application.yml에 적어주세요
- 백엔드 회의 후 merge할 예정

## ✅ 관련 이슈
- #1 