### PR TITLE
[Feat] 회원가입/비밀번호 재설정 이메일 검증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // json
     implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/doubleone/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/doubleone/domain/matching/controller/MatchingController.java
@@ -40,4 +40,5 @@ public class MatchingController {
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 
+
 }

--- a/src/main/java/org/doubleone/domain/member/controller/AuthController.java
+++ b/src/main/java/org/doubleone/domain/member/controller/AuthController.java
@@ -2,12 +2,19 @@ package org.doubleone.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.doubleone.domain.member.dto.request.*;
+import org.doubleone.domain.member.dto.response.EmailVerificationResponseDto;
 import org.doubleone.domain.member.dto.response.TokenResponseDto;
 import org.doubleone.domain.member.service.AuthService;
+import org.doubleone.domain.member.service.EmailSenderService;
 import org.doubleone.domain.member.service.MemberService;
+import org.doubleone.global.exception.CustomException;
+import org.doubleone.global.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,6 +29,7 @@ public class AuthController {
 
   private final AuthService authService;
   private final MemberService memberService;
+  private final EmailSenderService emailSenderService;
 
   @Operation(summary = "토큰 재발급", description = "refreshToken을 통해 accessToken을 재발급")
   @PostMapping("/token")
@@ -78,5 +86,24 @@ public class AuthController {
   @GetMapping("/center")
   public ResponseEntity<?> getCentersByKeyword(@RequestParam String keyword) {
     return ResponseEntity.ok(authService.getCentersByKeyword(keyword));
+  }
+
+  @Operation(summary = "이메일 인증번호 전송", description = "이메일 인증번호를 전송")
+  @PostMapping("/email/send")
+  public ResponseEntity<EmailVerificationResponseDto> sendVerificationEmail(@Valid @RequestBody EmailVerificationRequestDto requestDto) throws MessagingException {
+    emailSenderService.sendVerificationEmail(requestDto.getEmail());
+//    return ResponseEntity.ok(new EmailVerificationResponseDto(true, "인증번호 전송 완료"));
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  @Operation(summary = "이메일 인증번호 확인", description = "이메일 인증번호를 확인")
+  @GetMapping("/email/verify")
+  public ResponseEntity<EmailVerificationResponseDto> verifyEmail(@Valid @RequestBody EmailVerificationRequestDto verificationRequestDto) {
+    boolean isValid = emailSenderService.verifyCode(verificationRequestDto.getEmail(), verificationRequestDto.getVerificationCode());
+    if (isValid) {
+      return ResponseEntity.status(HttpStatus.OK).build();
+    } else {
+      throw new CustomException(ErrorCode.INCORRECT_VERIFICATION_CODE);
+    }
   }
 }

--- a/src/main/java/org/doubleone/domain/member/dto/request/EmailVerificationRequestDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/request/EmailVerificationRequestDto.java
@@ -1,0 +1,17 @@
+package org.doubleone.domain.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationRequestDto {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String verificationCode;
+
+}

--- a/src/main/java/org/doubleone/domain/member/dto/response/EmailVerificationResponseDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/response/EmailVerificationResponseDto.java
@@ -1,0 +1,12 @@
+package org.doubleone.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailVerificationResponseDto {
+    private boolean success;
+    private String message;
+
+}

--- a/src/main/java/org/doubleone/domain/member/service/EmailSenderService.java
+++ b/src/main/java/org/doubleone/domain/member/service/EmailSenderService.java
@@ -1,0 +1,110 @@
+package org.doubleone.domain.member.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMailMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailSenderService {
+
+    private JavaMailSender javaMailSender;
+
+    @Autowired
+    public EmailSenderService(JavaMailSender javaMailSender) {
+        this.javaMailSender = javaMailSender;
+    }
+
+    private final Map<String, String>verificationCodes = new HashMap<>();
+    private final Map<String, Long> expirationTimes = new HashMap<>();
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        StringBuilder verificationCode = new StringBuilder();
+        for(int i = 0; i < 6; i++) {
+            verificationCode.append(random.nextInt(10));
+        }
+        return verificationCode.toString();
+
+    }
+
+    private void sendEmail(String toMail, String subject, String body) throws MessagingException {
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+        mimeMessageHelper.setTo(toMail);
+        mimeMessageHelper.setSubject(subject);
+        mimeMessageHelper.setText(body, true);
+
+        javaMailSender.send(mimeMessage);
+    }
+
+    // 회원가입 인증 이메일 보내기
+    public void sendVerificationEmail(String toMail) throws MessagingException {
+        String verificationCode = generateVerificationCode();
+        String subject = "이메일 인증을 완료하세요!";
+        String body = "<html>"
+            + "<head>"
+            + "<style>"
+            + "  body { font-family: 'Arial', sans-serif; background-color: #f4f4f9; padding: 20px; margin: 0; }"
+            + "  .container { width: 100%; max-width: 600px; background-color: #ffffff; border-radius: 10px; padding: 20px; margin: 0 auto; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }"
+            + "  .header { font-family: 'Georgia', serif; font-size: 24px; font-weight: bold; color: #4CAF50; text-align: center; margin-bottom: 20px; }"
+            + "  .body-text { font-size: 16px; color: #333333; line-height: 1.6; text-align: center; margin-bottom: 20px; }"
+            + "  .verification-code { font-size: 18px; font-weight: bold; color: #FF5722; padding: 12px 30px; background-color: #f4f4f9; border-radius: 5px; text-align: center; }"
+            + "  .footer { font-size: 12px; color: #888888; text-align: center; margin-top: 30px; }"
+            + "  .brand-name { font-family: 'Georgia', serif; color: #4CAF50; font-weight: bold; font-size: 26px; }"
+            + "</style>"
+            + "</head>"
+            + "<body>"
+            + "<div class='container'>"
+            + "  <div class='header'>온림(溫林) 이메일 인증</div>"
+            + "  <div class='body-text'>아래 인증번호를 입력하셔서 인증을 진행해 주세요.</div>"
+            + "  <div class='verification-code'>" + verificationCode + "</div>"
+            + "  <div class='footer'>"
+            + "    <p>이 메일은 온림(溫林)에서 발송한 자동 이메일입니다. 만약, 본 이메일을 요청하지 않으셨다면 무시하셔도 됩니다.</p>"
+            + "    <p class='brand-name'>온림(溫林)</p>"
+            + "  </div>"
+            + "</div>"
+            + "</body>"
+            + "</html>";
+
+        verificationCodes.put(toMail, verificationCode);
+        expirationTimes.put(toMail, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+
+        sendEmail(toMail, subject, body);
+    }
+
+    // 비밀번호 재설정 인증번호 이메일 보내기
+//    public void sendPasswordResetEmail(String toMail) throws MessagingException {
+//        String verificationCode = generateVerificationCode();  // 인증번호 생성
+//        String subject = "비밀번호 재설정 인증번호";
+//        String body = "<h1>비밀번호 재설정을 위한 인증번호</h1>" +
+//            "<p>아래 인증번호를 입력하여 비밀번호 재설정을 완료해주세요:</p>" +
+//            "<p><strong>" + verificationCode + "</strong></p>";  // 인증번호 포함
+//
+//        verificationCodes.put(toMail, verificationCode);
+//        expirationTimes.put(toMail, System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+//
+//        sendEmail(toMail, subject, body);
+//    }
+
+    public boolean verifyCode(String toMail, String inputCode) {
+        String savedCode = verificationCodes.get(toMail);
+        Long expirationTime = expirationTimes.get(toMail);
+
+        if (savedCode == null || expirationTime == null || System.currentTimeMillis() > expirationTime) {
+            return false;
+        }
+
+        return savedCode.equals(inputCode);
+    }
+
+}

--- a/src/main/java/org/doubleone/global/exception/ErrorCode.java
+++ b/src/main/java/org/doubleone/global/exception/ErrorCode.java
@@ -43,7 +43,10 @@ public enum ErrorCode {
     SENIOR_CONDITION_NOT_FOUND(404, "노인 근무 조건을 찾을 수 없습니다."),
 
     // Matching
-    MATCHING_NOT_FOUND(404, "매칭을 찾을 수 없습니다.");
+    MATCHING_NOT_FOUND(400, "매칭을 찾을 수 없습니다."),
+
+  // Email
+  INCORRECT_VERIFICATION_CODE(400, "인증번호가 일치하지 않습니다.");
 
   private final int status;
   private final String message;


### PR DESCRIPTION
## 구현 기능 
- 회원가입/비밀번호 재설정 이메일 검증 
  
## 테스트 결과
- /email/send (post)
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/00044f19-44a4-4578-b82d-61b279c44504" />

- /email/verify (get)
1. 실패
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/90a8aa16-e3f6-4481-bcc7-c5cead9c6d14" />
2. 성공
<img width="971" alt="image" src="https://github.com/user-attachments/assets/a391a114-3a92-4455-8ef7-f0c8c47f1074" />


## 코멘트
- 논의가 필요한 부분, 개선 방향  

## 관련 이슈
- #이슈번호