### PR TITLE
[Feat] 카카오 로그인 / 회원 탈퇴 API 구현 / 센터 조회 API 수정 

### DIFF
--- a/src/main/java/org/doubleone/domain/manager/entity/Manager.java
+++ b/src/main/java/org/doubleone/domain/manager/entity/Manager.java
@@ -123,10 +123,11 @@ public class Manager extends BaseTimeEntity {
     this.hasTruck = hasTruck;
   }
 
-  // 회원탈퇴 처리
-  public void withdraw() {
-    this.isActive = false;
-  }
 
   public void updateCenterImg(String centerImg){this.centerImg = centerImg;}
+
+  public void deactivateMember() {
+    this.name = "(알 수 없음)";
+    this.profileImg = null;
+  }
 }

--- a/src/main/java/org/doubleone/domain/member/controller/AuthController.java
+++ b/src/main/java/org/doubleone/domain/member/controller/AuthController.java
@@ -71,6 +71,12 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.OK).body(authService.login(loginRequestDto));
   }
 
+  @Operation(summary = "카카오 로그인")
+  @PostMapping("/login/kakao")
+  public ResponseEntity<?> signInForKakao(@RequestBody LoginForKakaoRequestDto loginRequestDto) {
+    return ResponseEntity.status(HttpStatus.OK).body(authService.login(loginRequestDto));
+  }
+
   @Operation(summary = "개인정보 수정", description = "회원이 개인정보를 수정")
   @PatchMapping("/members/profile")
   public ResponseEntity<Void> updateProfile(
@@ -87,6 +93,13 @@ public class AuthController {
   public ResponseEntity<?> getCentersByKeyword(@RequestParam String keyword) {
     return ResponseEntity.ok(authService.getCentersByKeyword(keyword));
   }
+
+//  @Operation(summary = "회원 탈퇴", description = "회원을 INACTIVE 상태로 변경")
+//  @GetMapping("/deactivate/{memberId}")
+//  public ResponseEntity<?> deactivate(@PathVariable("memberId") Long memberId) {
+//    authService.deactivateMember(memberId);
+//    return ResponseEntity.ok().build();
+//  }
 
   @Operation(summary = "이메일 인증번호 전송", description = "이메일 인증번호를 전송")
   @PostMapping("/email/send")

--- a/src/main/java/org/doubleone/domain/member/controller/AuthController.java
+++ b/src/main/java/org/doubleone/domain/member/controller/AuthController.java
@@ -94,12 +94,12 @@ public class AuthController {
     return ResponseEntity.ok(authService.getCentersByKeyword(keyword));
   }
 
-//  @Operation(summary = "회원 탈퇴", description = "회원을 INACTIVE 상태로 변경")
-//  @GetMapping("/deactivate/{memberId}")
-//  public ResponseEntity<?> deactivate(@PathVariable("memberId") Long memberId) {
-//    authService.deactivateMember(memberId);
-//    return ResponseEntity.ok().build();
-//  }
+  @Operation(summary = "회원 탈퇴", description = "회원을 INACTIVE 상태로 변경")
+  @GetMapping("/deactivate/{memberId}")
+  public ResponseEntity<?> deactivate(@PathVariable("memberId") Long memberId) {
+    authService.deactivateMember(memberId);
+    return ResponseEntity.noContent().build();
+  }
 
   @Operation(summary = "이메일 인증번호 전송", description = "이메일 인증번호를 전송")
   @PostMapping("/email/send")

--- a/src/main/java/org/doubleone/domain/member/dto/request/LoginForKakaoRequestDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/request/LoginForKakaoRequestDto.java
@@ -1,0 +1,10 @@
+package org.doubleone.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginForKakaoRequestDto(
+    @NotBlank
+    String account_email
+) {
+
+}

--- a/src/main/java/org/doubleone/domain/member/dto/response/CenterResponseDto.java
+++ b/src/main/java/org/doubleone/domain/member/dto/response/CenterResponseDto.java
@@ -1,5 +1,0 @@
-package org.doubleone.domain.member.dto.response;
-
-public class CenterResponseDto {
-
-}

--- a/src/main/java/org/doubleone/domain/member/entity/Member.java
+++ b/src/main/java/org/doubleone/domain/member/entity/Member.java
@@ -65,4 +65,7 @@ public class Member extends BaseTimeEntity {
   }
 
 
+  public void deactivateMember() {
+    this.memberstatus = MemberStatus.INACTIVE;
+  }
 }

--- a/src/main/java/org/doubleone/domain/member/service/AuthService.java
+++ b/src/main/java/org/doubleone/domain/member/service/AuthService.java
@@ -222,10 +222,18 @@ public class AuthService {
         .collect(Collectors.toList());
   }
 
-
-//  public void deactivateMember(Long memberId) {
-//    Member member = memberRepository.findById(memberId)
-//        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-//    member.deactivateMember()
-//  }
+  public void deactivateMember(Long memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    member.deactivateMember();
+    if (member.getMemberType() == MemberType.WORKER){
+      Worker worker = workerRepository.findByMember(member);
+      worker.deactivateMember();
+    } else if (member.getMemberType() == MemberType.MANAGER){
+      Manager manager = managerRepository.findByMember(member);
+      manager.deactivateMember();
+    } else {
+      throw new CustomException(ErrorCode.ACCESS_DENIED);
+    }
+  }
 }

--- a/src/main/java/org/doubleone/domain/member/service/AuthService.java
+++ b/src/main/java/org/doubleone/domain/member/service/AuthService.java
@@ -1,12 +1,15 @@
 package org.doubleone.domain.member.service;
 
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.doubleone.domain.center.entity.Center;
 import org.doubleone.domain.center.repository.CenterRepository;
 import org.doubleone.domain.manager.entity.Manager;
 import org.doubleone.domain.manager.repository.ManagerRepository;
+import org.doubleone.domain.member.dto.request.LoginForKakaoRequestDto;
 import org.doubleone.domain.member.dto.request.LoginRequestDto;
 import org.doubleone.domain.member.dto.request.SignupManagerDto;
 import org.doubleone.domain.member.dto.request.SignupManagerForKakaoDto;
@@ -165,6 +168,30 @@ public class AuthService {
 
     }
 
+  public LoginResponseDto login(LoginForKakaoRequestDto requestDto){
+    String email = requestDto.account_email();
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    // Worker, Manager 조회
+    Worker worker = workerRepository.findOptionalByMember(member).orElse(null);
+    Manager manager = managerRepository.findOptionalByMember(member).orElse(null);
+
+    Long workerId = (worker != null) ? worker.getWorkerId() : null;
+    Long managerId = (manager != null) ? manager.getManagerId() : null;
+
+    // AccessToken, RefreshToken 발급
+    String accessToken = tokenProvider.createAccessToken(member);
+    String refreshToken = tokenProvider.createRefreshToken(member);
+
+    // 리프레시 토큰 저장
+    tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+    // LoginResponseDto 반환
+    return LoginResponseDto.from(accessToken, refreshToken, member, workerId, managerId);
+
+  }
+
   public TokenResponseDto reissueAccessToken(String refreshToken){
     // 전달받은 리프레시 토큰에서 이메일을 추출하여 사용자 정보 가져오기
     String email = tokenProvider.extractEmail(refreshToken);
@@ -191,7 +218,7 @@ public class AuthService {
   @Transactional(readOnly = true)
   public List<String> getCentersByKeyword(String keyword) {
     return centerRepository.findByCenterNameContaining(keyword).stream()
-        .map(center -> center.getCenterCode() + "," + center.getCenterName())
+        .map(Center::getCenterName)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/doubleone/domain/member/service/AuthService.java
+++ b/src/main/java/org/doubleone/domain/member/service/AuthService.java
@@ -2,6 +2,7 @@ package org.doubleone.domain.member.service;
 
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import org.doubleone.domain.member.dto.request.SignupWorkerForKakaoDto;
 import org.doubleone.domain.member.dto.response.LoginResponseDto;
 import org.doubleone.domain.member.dto.response.TokenResponseDto;
 import org.doubleone.domain.member.entity.Member;
+import org.doubleone.domain.member.entity.MemberStatus;
 import org.doubleone.domain.member.entity.MemberType;
 import org.doubleone.domain.member.repository.MemberRepository;
 import org.doubleone.domain.worker.entity.Worker;
@@ -49,8 +51,14 @@ public class AuthService {
 
 
   public void signUpManager(SignupManagerDto requestDto) {
-    // 이메일 중복 체크
-    if (memberRepository.existsByEmail(requestDto.getEmail())) {
+    Optional<Member> memberOptional = memberRepository.findByEmail(requestDto.getEmail());
+    if (memberOptional.isPresent()) {
+      Member member = memberOptional.get();
+      // 탈퇴한 사용자 에러 처리
+      if (member.getMemberstatus() == MemberStatus.INACTIVE) {
+        throw new CustomException(ErrorCode.MEMBER_ALREADY_WITHDRAWN);
+      }
+      // 중복 이메일 에러 처리
       throw new CustomException(ErrorCode.MEMBER_ALREADY_EXISTS);
     }
     // 비밀번호 일치 검사
@@ -83,7 +91,7 @@ public class AuthService {
   public void signUpManagerForKakao(SignupManagerForKakaoDto requestDto) {
     Member member = memberRepository.findById(requestDto.memberId())
         .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-    if(member.getMemberType() != MemberType.UNKNOWN){
+    if (member.getMemberType() != MemberType.UNKNOWN){
       throw new CustomException(ErrorCode.ACCESS_DENIED);
     }
     Manager manager = Manager.builder()
@@ -101,8 +109,14 @@ public class AuthService {
   }
 
   public void signUpWorker(SignupWorkerDto requestDto) {
-    // 이메일 중복 체크
-    if (memberRepository.existsByEmail(requestDto.getEmail())) {
+    Optional<Member> memberOptional = memberRepository.findByEmail(requestDto.getEmail());
+    if (memberOptional.isPresent()) {
+      Member member = memberOptional.get();
+      // 탈퇴한 사용자 에러 처리
+      if (member.getMemberstatus() == MemberStatus.INACTIVE) {
+        throw new CustomException(ErrorCode.MEMBER_ALREADY_WITHDRAWN);
+      }
+      // 중복 이메일 에러 처리
       throw new CustomException(ErrorCode.MEMBER_ALREADY_EXISTS);
     }
     // 멤버에 기본정보 등록

--- a/src/main/java/org/doubleone/domain/worker/entity/Worker.java
+++ b/src/main/java/org/doubleone/domain/worker/entity/Worker.java
@@ -88,4 +88,9 @@ public class Worker extends BaseTimeEntity {
   public void updateProfileImg(String profileImg) {
     this.profileImg = profileImg;
   }
+
+  public void deactivateMember() {
+    this.name = "(알 수 없음)";
+    this.profileImg = null;
+  }
 }

--- a/src/main/java/org/doubleone/global/exception/ErrorCode.java
+++ b/src/main/java/org/doubleone/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(404, "멤버를 찾을 수 없습니다."),
   MEMBER_ALREADY_EXISTS(409, "해당 이메일을 가진 멤버가 존재합니다."),
   PASSWORD_MISMATCH(400, "비밀번호가 일치하지 않습니다."),
+  MEMBER_ALREADY_WITHDRAWN(409, "탈퇴한 이메일로는 재가입이 불가능합니다."),
 
   // Manager
   MANAGER_CANNOT_CREATE_CHAT(409, "관리자는 채팅을 시작할 수 없습니다."),

--- a/src/main/java/org/doubleone/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/doubleone/global/exception/GlobalExceptionHandler.java
@@ -2,9 +2,16 @@ package org.doubleone.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,7 +22,6 @@ public class GlobalExceptionHandler {
   @ExceptionHandler({CustomException.class})
   protected ResponseEntity<ErrorDto> handleCustomException(CustomException e,
       HttpServletRequest request) {
-    log.error(e);
     ErrorDto errorDto = ErrorDto.builder()
         .timestamp(LocalDateTime.now().toString())
         .status(e.getErrorCode().getStatus())
@@ -24,5 +30,28 @@ public class GlobalExceptionHandler {
         .build();
     return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
   }
+
+  @ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
+  protected ResponseEntity<ErrorDto> handleValidationException(Exception e, HttpServletRequest request) {
+    BindingResult bindingResult = null;
+
+    if (e instanceof BindException) {
+      bindingResult = ((BindException) e).getBindingResult();
+    } else if (e instanceof MethodArgumentNotValidException) {
+      bindingResult = ((MethodArgumentNotValidException) e).getBindingResult();
+    }
+    List<String> errorMessages = bindingResult.getFieldErrors().stream()
+        .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+        .collect(Collectors.toList());
+
+    ErrorDto errorDto = ErrorDto.builder()
+        .timestamp(LocalDateTime.now().toString())
+        .message(String.join(", ", errorMessages))
+        .path(request.getRequestURI())
+        .build();
+
+    return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+  }
+
 
 }


### PR DESCRIPTION
## 구현 기능 
- 카카오 로그인 API 구현
- 센터 조회 API 이름만 응답하도록 수정 
- 회원 탈퇴 API 구현

## 관련 이슈
- #1 
- #31 
