### PR TITLE
[Refactor] 하위지역 반환 코드 수정

### DIFF
--- a/src/main/java/org/doubleone/domain/address/controller/AddressController.java
+++ b/src/main/java/org/doubleone/domain/address/controller/AddressController.java
@@ -1,6 +1,7 @@
 package org.doubleone.domain.address.controller;
 
 
+import org.doubleone.domain.address.service.AddressService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -9,36 +10,22 @@ import java.util.*;
 @RestController
 @RequestMapping("/address")
 public class AddressController {
-    private final Map<String, List<String>> cityData = new HashMap<>();
-    private final Map<String, List<String>> districtData = new HashMap<>();
+    private final AddressService addressService;
 
-    // 특정 도시의 지역 리스트 반환
-    @GetMapping("/city/{cityName}")
-    public List<String> getCityData(@PathVariable String cityName) {
-        return cityData.getOrDefault(cityName, Collections.emptyList());
+    public AddressController(AddressService addressService)
+    {
+        this.addressService = addressService;
     }
 
-    // 특정 구/지역의 하위 지역 리스트 반환
-    @GetMapping("/district/{districtName}")
-    public List<String> getDistrictData(@PathVariable String districtName) {
-        return districtData.getOrDefault(districtName, Collections.emptyList());
+    // 도시별 구 리스트 반환 API
+    @GetMapping("/city/{city}")
+    public List<String> getDistrictsByCity(@PathVariable String city) {
+        return addressService.getDistrictsByCity(city);
     }
 
-    // 새로운 도시와 지역추가(프론트연결X)
-    @PostMapping("/city")
-    public ResponseEntity<?> addCityData(@RequestBody Map<String, List<String>> newCityData) {
-        for (Map.Entry<String, List<String>> entry : newCityData.entrySet()) {
-            cityData.put(entry.getKey(), new ArrayList<>(entry.getValue()));
-        }
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
-
-    // 새로운 구와 하위지역 추가(프론트연결X)
-    @PostMapping("/district")
-    public ResponseEntity<?> addDistrictData(@RequestBody Map<String, List<String>> newDistrictData) {
-        for (Map.Entry<String, List<String>> entry : newDistrictData.entrySet()) {
-            districtData.put(entry.getKey(), new ArrayList<>(entry.getValue()));
-        }
-        return ResponseEntity.status(HttpStatus.OK).build();
+    // 구/군별 행정동 리스트 반환 API
+    @GetMapping("/district/{district}")
+    public List<String> getNeighborhoodsByDistrict(@PathVariable String district) {
+        return addressService.getNeighborhoodsByDistrict(district);
     }
 }

--- a/src/main/java/org/doubleone/domain/address/entity/Address.java
+++ b/src/main/java/org/doubleone/domain/address/entity/Address.java
@@ -2,9 +2,11 @@ package org.doubleone.domain.address.entity;
 
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @Entity
 @Table(name="address")
 public class Address {
@@ -12,8 +14,22 @@ public class Address {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String city;
+    @Column(nullable = false)
+    private String city; // 도시
+
+    @Column(nullable = false)
+    private String district; // 구
+
+    @Column(nullable = true)
+    private String neighborhood; // 행정동(null ok)
+
+    public Address() {}
+
+    public Address(String city, String district, String neighborhood) {
+        this.city = city;
+        this.district = district;
+        this.neighborhood = neighborhood;
+    }
 
 
 }

--- a/src/main/java/org/doubleone/domain/address/repository/AddressRepository.java
+++ b/src/main/java/org/doubleone/domain/address/repository/AddressRepository.java
@@ -3,5 +3,10 @@ package org.doubleone.domain.address.repository;
 import org.doubleone.domain.address.entity.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AddressRepository extends JpaRepository<Address, Long> {
+    List<Address> findByCity(String city);
+    List<Address> findByDistrict(String district);
+
 }

--- a/src/main/java/org/doubleone/domain/address/service/AddressService.java
+++ b/src/main/java/org/doubleone/domain/address/service/AddressService.java
@@ -1,0 +1,37 @@
+package org.doubleone.domain.address.service;
+
+import org.doubleone.domain.address.entity.Address;
+import org.doubleone.domain.address.repository.AddressRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class AddressService {
+    private final AddressRepository addressRepository;
+
+    public AddressService(AddressRepository addressRepository)
+    {
+        this.addressRepository = addressRepository;
+    }
+
+    // 도시별 구 리스트 반환
+    public List<String> getDistrictsByCity(String city) {
+        return addressRepository.findByCity(city).stream()
+                .map(Address::getDistrict)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    // 구별 행정동 리스트 반환
+    public List<String> getNeighborhoodsByDistrict(String district) {
+        return addressRepository.findByDistrict(district).stream()
+                .map(Address::getNeighborhood)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/doubleone/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/doubleone/domain/matching/repository/MatchingRepository.java
@@ -1,19 +1,24 @@
 package org.doubleone.domain.matching.repository;
 
+import org.doubleone.domain.condition.entity.Condition;
 import org.doubleone.domain.manager.entity.Manager;
 import org.doubleone.domain.matching.entity.Matching;
 import org.doubleone.domain.matching.entity.MatchingStatus;
 import org.doubleone.domain.matching.entity.RunningStatus;
 //import org.doubleone.domain.worker.dto.response.WorkerMatchingAlarmUnitDto;
 import org.doubleone.domain.worker.entity.Worker;
+import org.doubleone.domain.workerCondition.entity.WorkerCondition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
     List<Matching> findByMatchingStatus(MatchingStatus matchingStatus);
+    Optional<Matching> findByConditionAndWorkerCondition(Condition condition, WorkerCondition workerCondition);
 
     @Query("SELECT COUNT(DISTINCT m.condition.senior) FROM Matching m WHERE m.condition.senior.manager = :manager")
     int countByManager(@Param("manager") Manager manager);

--- a/src/main/java/org/doubleone/domain/worker/dto/WorkerDetailDto.java
+++ b/src/main/java/org/doubleone/domain/worker/dto/WorkerDetailDto.java
@@ -13,4 +13,5 @@ public class WorkerDetailDto {
     private String workerName;
     private List<WorkerRegionDto> workerRegions;
     private List<WorkPeriodDto> workPeriods;
+    private Long matchingId;
 }

--- a/src/main/java/org/doubleone/domain/worker/service/WorkerMatchService.java
+++ b/src/main/java/org/doubleone/domain/worker/service/WorkerMatchService.java
@@ -2,6 +2,10 @@ package org.doubleone.domain.worker.service;
 
 import org.doubleone.domain.condition.entity.Condition;
 import org.doubleone.domain.condition.repository.ConditionRepository;
+import org.doubleone.domain.matching.entity.Matching;
+import org.doubleone.domain.matching.entity.MatchingStatus;
+import org.doubleone.domain.matching.entity.RunningStatus;
+import org.doubleone.domain.matching.repository.MatchingRepository;
 import org.doubleone.domain.senior.entity.Senior;
 import org.doubleone.domain.senior.repository.SeniorRepository;
 import org.doubleone.domain.worker.dto.WorkPeriodDto;
@@ -27,11 +31,13 @@ public class WorkerMatchService {
     private final WorkerService workerService;
     private final SeniorRepository seniorRepository;
     private final ConditionRepository conditionRepository;
+    private final MatchingRepository matchingRepository;
 
-    public WorkerMatchService(WorkerService workerService, SeniorRepository seniorRepository, ConditionRepository conditionRepository) {
+    public WorkerMatchService(WorkerService workerService, SeniorRepository seniorRepository, ConditionRepository conditionRepository, MatchingRepository matchingRepository) {
         this.workerService = workerService;
         this.seniorRepository = seniorRepository;
         this.conditionRepository = conditionRepository;
+        this.matchingRepository = matchingRepository;
     }
 
     public WorkerMatchResponseDto findWorkersBySenior(Long seniorId) {
@@ -60,11 +66,23 @@ public class WorkerMatchService {
                             workPeriod.getEndDate()
                     )).collect(Collectors.toList()) : List.of();
 
+            Matching matching = matchingRepository.findByConditionAndWorkerCondition(condition, workerCondition)
+                    .orElseGet(() -> {
+                        Matching newMatching = Matching.builder()
+                                .condition(condition)
+                                .workerCondition(workerCondition)
+                                .matchingStatus(MatchingStatus.BEFORE_REQUEST)
+                                .runningStatus(RunningStatus.WAITING)
+                                .build();
+                        return matchingRepository.save(newMatching);
+                    });
+
             return WorkerDetailDto.builder()
                     .workerId(worker.getWorkerId())
                     .workerName(worker.getName())
                     .workerRegions(regionDtos)
                     .workPeriods(workPeriods)
+                    .matchingId(matching.getMatchingId())
                     .build();
         }).collect(Collectors.toList());
 


### PR DESCRIPTION
## 구현 기능 
- 시/구/동 지역 반환하는거 오류있어서 수정했습니다.
- 매칭된 요양사 조회에서 매칭아이디 반환되도록 추가했습니다.
  
## 테스트 결과
![image](https://github.com/user-attachments/assets/86fabd2b-3ee7-45e4-9ab0-9a220dc64fd6)
![image](https://github.com/user-attachments/assets/9ecdc2a8-5ae9-43ca-bcb9-1d40df575c2e)
![image](https://github.com/user-attachments/assets/198fe069-2489-4dc0-b822-ce25b905fbcd)


## 코멘트
서버db에 insert로 시/구/동 채워넣을 예정입니다.

## 관련 이슈

